### PR TITLE
 fix: add error popup display for file processing failures 🔧

### DIFF
--- a/ev1-dec.py
+++ b/ev1-dec.py
@@ -1,37 +1,45 @@
 import os, tkinter, windnd, chardet, locale
+from tkinter import messagebox
 
-def dnd_file(files):
+def dnd_file(files, root_window=None):
     for file in files:
         try:
-            file = file.decode(sys_enc)
-        except UnicodeDecodeError:
-            file = file.decode('utf-8')
+            try:
+                file = file.decode(sys_enc)
+            except UnicodeDecodeError:
+                file = file.decode('utf-8')
+        except Exception as e:
+            messagebox.showerror("解码错误", f"无法解码文件路径:\n{type(e).__name__}: {e}", parent=root_window)
+            continue
 
         if (file.split(".")[-1] != "ev1"):
             print(f"Ignore {file}")
             continue
 
         print(f"Convert {file}")
-        with open(file, 'rb+') as f:
-            raw = f.read(100)
-            data = bytearray(raw)
+        try:
+            with open(file, 'rb+') as f:
+                raw = f.read(100)
+                data = bytearray(raw)
 
-            for idx, b in enumerate(data):
-                data[idx] = b ^ 0xff
-            
-            raw = bytes(data)
-            f.seek(0)
-            f.write(raw)
-            f.close()
+                for idx, b in enumerate(data):
+                    data[idx] = b ^ 0xff
 
-            os.rename(file, file + '.flv')
+                raw = bytes(data)
+                f.seek(0)
+                f.write(raw)
+                f.close()
+
+                os.rename(file, file + '.flv')
+        except Exception as e:
+            messagebox.showerror("文件处理错误", f"处理文件时出错 '{file}':\n{type(e).__name__}: {e}", parent=root_window)
 
 sys_enc = locale.getpreferredencoding()
 
 root = tkinter.Tk()
 root.geometry('400x300')
 root.title('DV1: EV1 Decoder')
-windnd.hook_dropfiles(root, func=dnd_file)
+windnd.hook_dropfiles(root, func=lambda files: dnd_file(files, root_window=root))
 label = tkinter.Label(root, text ='Drop *.ev1 on me :)')
 label.place(relx = 0.5, rely = 0.5, anchor = 'center')
 root.mainloop()


### PR DESCRIPTION
  - Added `tkinter.messagebox` import for error popup functionality
  - Enhanced `dnd_file` function with two-layer error handling:
    - File path decoding errors (Unicode decode issues)
    - File operation errors (open/read/write/rename failures)
  - Modified `windnd.hook_dropfiles` call to pass parent window parameter
  - All potential errors now display user-friendly popup dialogs with:
    - Error type (Exception class name)
    - Detailed error message
    - Relevant filename (when applicable)
  - Previous silent failures now provide clear visual feedback to users

  ✨ Users will now see proper error popups for:
    - File encoding/decoding issues
    - File not found or inaccessible
    - Permission denied errors
    - Disk space不足
    - File rename conflicts
    - Other I/O operation exceptions

  📝 This fix addresses the issue where the GUI would appear unresponsive when
  errors occurred, with no feedback to users.

  🔗 close #5